### PR TITLE
Adding support for door/window sensors identifying as mc

### DIFF
--- a/custom_components/tuya_v2/binary_sensor.py
+++ b/custom_components/tuya_v2/binary_sensor.py
@@ -32,6 +32,7 @@ from .const import (
 _LOGGER = logging.getLogger(__name__)
 
 TUYA_SUPPORT_TYPE = [
+    "mc",  # Door Window Sensor
     "mcs",  # Door Window Sensor
     "ywbj",  # Smoke Detector
     "rqbj",  # Gas Detector


### PR DESCRIPTION
Adding support for door/window sensors identifying as `mc`, like these ones: [NEO COOLCAM Wifi Door Window Sensor](https://www.aliexpress.com/item/32858144085.html)