### PR TITLE
🔩Code: Air Purifier support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,3 +136,6 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# MacOS files
+.DS_Store

--- a/custom_components/tuya_v2/const.py
+++ b/custom_components/tuya_v2/const.py
@@ -45,3 +45,7 @@ TUYA_SUPPORT_HA_TYPE = [
     "vacuum"
     # 'alarm_control_panel'
 ]
+
+TUYA_AIR_PURIFIER_TYPE = "kj"
+TUYA_FAN_TYPE = "fs"
+TUYA_PET_WATER_FEEDER_TYPE = "cwysj"

--- a/custom_components/tuya_v2/fan.py
+++ b/custom_components/tuya_v2/fan.py
@@ -187,10 +187,14 @@ class TuyaHaFan(TuyaHaDevice, FanEntity):
     @property
     def preset_modes(self) -> list:
         """Return the list of available preset_modes."""
-        data = json.loads(self.tuya_device.function.get(DPCODE_MODE, {}).values).get(
-            "range"
-        )
-        return data
+        try:
+            data = json.loads(self.tuya_device.function.get(DPCODE_MODE, {}).values).get(
+                "range"
+            )
+            return data
+        except:
+            _LOGGER.warn("Cannot parse the preset modes")
+        return []
 
     @property
     def preset_mode(self) -> str:

--- a/custom_components/tuya_v2/fan.py
+++ b/custom_components/tuya_v2/fan.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 import json
 import logging
 from typing import Any
+from math import ceil
+
+from homeassistant.util.percentage import int_states_in_range, ranged_value_to_percentage, percentage_to_ranged_value
 
 from homeassistant.components.fan import (
     DIRECTION_FORWARD,
@@ -27,6 +30,8 @@ from .const import (
     TUYA_DISCOVERY_NEW,
     TUYA_HA_DEVICES,
     TUYA_HA_TUYA_MAP,
+    TUYA_AIR_PURIFIER_TYPE,
+    TUYA_FAN_TYPE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -40,8 +45,15 @@ DPCODE_MODE = "mode"
 DPCODE_SWITCH_HORIZONTAL = "switch_horizontal"
 DPCODE_FAN_DIRECTION = "fan_direction"
 
-TUYA_SUPPORT_TYPE = {"fs"}  # Fan
+# Air Purifier
+# https://developer.tuya.com/en/docs/iot/s?id=K9gf48r41mn81
+DPCODE_AP_FAN_SPEED      = "speed"
+DPCODE_AP_FAN_SPEED_ENUM = "fan_speed_enum"
 
+TUYA_SUPPORT_TYPE = {
+    TUYA_FAN_TYPE,
+    TUYA_AIR_PURIFIER_TYPE
+}
 
 async def async_setup_entry(
     hass: HomeAssistant, _entry: ConfigEntry, async_add_entities
@@ -86,6 +98,33 @@ def _setup_entities(hass, device_ids: list):
 
 class TuyaHaFan(TuyaHaDevice, FanEntity):
     """Tuya Fan Device."""
+    
+    def __init__(self, device: TuyaDevice, device_manager: TuyaDeviceManager):
+        """Init Tuya Fan Device."""
+        super().__init__(device, device_manager)
+        
+        # Air purifier fan can be controlled either via the ranged values or via the enum.
+        # We will always prefer the enumeration if available
+        #   Enum is used for e.g. MEES SmartHIMOX-H06
+        #   Range is used for e.g. Concept CA3000
+        self.air_purifier_speed_range      = (0, 0)
+        self.air_purifier_speed_range_len  = 0
+        self.air_purifier_speed_range_enum = []
+        if self.tuya_device.category == TUYA_AIR_PURIFIER_TYPE:
+            try:
+                if DPCODE_AP_FAN_SPEED_ENUM in self.tuya_device.status:
+                    data = json.loads(self.tuya_device.function.get(DPCODE_AP_FAN_SPEED_ENUM, {}).values).get("range")
+                    if data:
+                        self.air_purifier_speed_range = (1, len(data))
+                        self.air_purifier_speed_range_len = len(data)
+                        self.air_purifier_speed_range_enum = data
+                elif DPCODE_AP_FAN_SPEED in self.tuya_device.status:
+                    data = json.loads(self.tuya_device.function.get(DPCODE_AP_FAN_SPEED, {}).values).get("range")
+                    if data:
+                        self.air_purifier_speed_range = (int(data[0]), int(data[-1]))
+                        self.air_purifier_speed_range_len = len(data)
+            except:
+                _LOGGER.warn("Cannot parse the air-purifier speed range")
 
     def set_preset_mode(self, preset_mode: str) -> None:
         """Set the preset mode of the fan."""
@@ -94,9 +133,21 @@ class TuyaHaFan(TuyaHaDevice, FanEntity):
     def set_direction(self, direction: str) -> None:
         """Set the direction of the fan."""
         self._send_command([{"code": DPCODE_FAN_DIRECTION, "value": direction}])
+        
+    def set_percentage(self, percentage: int) -> None:
+        """Set the speed of the fan, as a percentage."""
+        if self.tuya_device.category == TUYA_AIR_PURIFIER_TYPE:
+            value_in_range = ceil(percentage_to_ranged_value(self.air_purifier_speed_range, percentage))
+            if len(self.air_purifier_speed_range_enum):
+                # if air-purifier speed enumeration is supported we will prefer it.
+                self._send_command([{"code": DPCODE_AP_FAN_SPEED_ENUM, "value": str(self.air_purifier_speed_range_enum[value_in_range - 1])}])
+            else:
+                self._send_command([{"code": DPCODE_AP_FAN_SPEED, "value": str(value_in_range)}])
+        else:
+            super().set_percentage(percentage)
 
     def turn_off(self, **kwargs: Any) -> None:
-        """Turn the device off."""
+        """Turn the fan off."""
         self._send_command([{"code": DPCODE_SWITCH, "value": False}])
 
     def turn_on(
@@ -151,7 +202,31 @@ class TuyaHaFan(TuyaHaDevice, FanEntity):
         """Return the current speed."""
         if not self.is_on:
             return 0
-        return self.tuya_device.status.get(DPCODE_FAN_SPEED, 0)
+            
+        if self.tuya_device.category == TUYA_AIR_PURIFIER_TYPE:
+            if self.air_purifier_speed_range_len > 1:
+                if len(self.air_purifier_speed_range_enum):
+                    # if air-purifier speed enumeration is supported we will prefer it.
+                    index = self.air_purifier_speed_range_enum.index(
+                        self.tuya_device.status.get(DPCODE_AP_FAN_SPEED_ENUM, 0)
+                    )
+                    return ranged_value_to_percentage(self.air_purifier_speed_range,
+                        index + 1
+                    )
+                else:
+                    return ranged_value_to_percentage(self.air_purifier_speed_range,
+                        int(self.tuya_device.status.get(DPCODE_AP_FAN_SPEED, 0)
+                    )
+            )
+        else:
+            return self.tuya_device.status.get(DPCODE_FAN_SPEED, 0)
+
+    @property
+    def speed_count(self) -> int:
+        """Return the number of speeds the fan supports."""
+        if self.tuya_device.category == TUYA_AIR_PURIFIER_TYPE:
+            return self.air_purifier_speed_range_len
+        return super().speed_count()
 
     @property
     def supported_features(self):
@@ -165,4 +240,10 @@ class TuyaHaFan(TuyaHaDevice, FanEntity):
             supports = supports | SUPPORT_OSCILLATE
         if DPCODE_FAN_DIRECTION in self.tuya_device.status:
             supports = supports | SUPPORT_DIRECTION
+        if DPCODE_FAN_SPEED in self.tuya_device.status:
+            supports = supports | SUPPORT_SET_SPEED
+           
+        # Air Purifier specific
+        if DPCODE_AP_FAN_SPEED in self.tuya_device.status or DPCODE_AP_FAN_SPEED_ENUM in self.tuya_device.status:
+            supports = supports | SUPPORT_SET_SPEED
         return supports

--- a/custom_components/tuya_v2/fan.py
+++ b/custom_components/tuya_v2/fan.py
@@ -240,8 +240,6 @@ class TuyaHaFan(TuyaHaDevice, FanEntity):
             supports = supports | SUPPORT_OSCILLATE
         if DPCODE_FAN_DIRECTION in self.tuya_device.status:
             supports = supports | SUPPORT_DIRECTION
-        if DPCODE_FAN_SPEED in self.tuya_device.status:
-            supports = supports | SUPPORT_SET_SPEED
            
         # Air Purifier specific
         if DPCODE_AP_FAN_SPEED in self.tuya_device.status or DPCODE_AP_FAN_SPEED_ENUM in self.tuya_device.status:

--- a/custom_components/tuya_v2/sensor.py
+++ b/custom_components/tuya_v2/sensor.py
@@ -15,8 +15,13 @@ from homeassistant.const import (
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_TEMPERATURE,
     DEVICE_CLASS_ILLUMINANCE,
+    DEVICE_CLASS_CO2,
     PERCENTAGE,
     TEMP_CELSIUS,
+    CONCENTRATION_PARTS_PER_MILLION,
+    TIME_DAYS,
+    TIME_MINUTES,
+    MASS_MILLIGRAMS,
 )
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.dispatcher import async_dispatcher_connect
@@ -28,6 +33,7 @@ from .const import (
     TUYA_DISCOVERY_NEW,
     TUYA_HA_DEVICES,
     TUYA_HA_TUYA_MAP,
+    TUYA_AIR_PURIFIER_TYPE,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -46,6 +52,7 @@ TUYA_SUPPORT_TYPE = [
     "wk",  # Thermostat
     "dlq",  # Breaker
     "ldcg",  # Luminance Sensor
+    TUYA_AIR_PURIFIER_TYPE, # Air Purifier
 ]
 
 # Smoke Detector
@@ -71,6 +78,19 @@ DPCODE_VOLTAGE = "cur_voltage"
 DPCODE_TOTAL_FORWARD_ENERGY = "total_forward_energy"
 
 DPCODE_BRIGHT_VALUE = "bright_value"
+
+# Air Purifier
+# https://developer.tuya.com/en/docs/iot/s?id=K9gf48r41mn81
+DPCODE_AP_PM25 = "pm25"                 # PM25 - no units
+DPCODE_AP_FILTER = "filter"             # Filter cartridge utilization [%]
+DPCODE_AP_TEMP = "temp"                 # Temperature [℃]
+DPCODE_AP_HUMIDITY = "humidity"         # Humidity [%]
+DPCODE_AP_TVOC = "tvoc"                 # Total Volatile Organic Compounds [ppm]
+DPCODE_AP_ECO2 = "eco2"                 # Carbon dioxide concentration [ppm]
+DPCODE_AP_FDAYS = "filter_days"         # Remaining days of the filter cartridge [day]
+DPCODE_AP_TTIME = "total_time"          # Total operating time [minute]
+DPCODE_AP_TPM = "total_pm"              # Total absorption of particles [mg]
+DPCODE_AP_COUNTDOWN = "countdown_left"  # Remaining time of countdown [minute]
 
 
 async def async_setup_entry(
@@ -110,169 +130,271 @@ def _setup_entities(hass, device_ids: List):
         device = device_manager.device_map[device_id]
         if device is None:
             continue
+            
+        if device.category == TUYA_AIR_PURIFIER_TYPE:
+            if DPCODE_AP_PM25 in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "PM25",
+                        DPCODE_AP_PM25,
+                        ""
+                    )
+                )
+            elif DPCODE_AP_FILTER in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "Filter",
+                        DPCODE_AP_FILTER,
+                        PERCENTAGE
+                    )
+                )
+            elif DPCODE_AP_TEMP in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_TEMPERATURE,
+                        DPCODE_AP_TEMP,
+                        TEMP_CELSIUS,
+                    )
+                )
+            elif DPCODE_AP_HUMIDITY in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_HUMIDITY,
+                        DPCODE_AP_HUMIDITY,
+                        PERCENTAGE,
+                    )
+                )
+            elif DPCODE_AP_TVOC in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "TVOC",
+                        DPCODE_AP_TVOC,
+                        CONCENTRATION_PARTS_PER_MILLION
+                    )
+                )
+            elif DPCODE_AP_ECO2 in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_CO2,
+                        DPCODE_AP_ECO2,
+                        CONCENTRATION_PARTS_PER_MILLION
+                    )
+                )
+            elif DPCODE_AP_FDAYS in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "FilterDays",
+                        DPCODE_AP_FDAYS,
+                        TIME_DAYS
+                    )
+                )
+            elif DPCODE_AP_TTIME in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "TotalTime",
+                        DPCODE_AP_TTIME,
+                        TIME_MINUTES
+                    )
+                )
+            elif DPCODE_AP_TPM in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "TotalPM",
+                        DPCODE_AP_TPM,
+                        MASS_MILLIGRAMS
+                    )
+                )
+            elif DPCODE_AP_COUNTDOWN in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "Countdown",
+                        DPCODE_AP_COUNTDOWN,
+                        TIME_MINUTES
+                    )
+                )
+        else:
+            if DPCODE_BATTERY in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_BATTERY,
+                        DPCODE_BATTERY,
+                        PERCENTAGE,
+                    )
+                )
+            if DPCODE_BATTERY_PERCENTAGE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_BATTERY,
+                        DPCODE_BATTERY_PERCENTAGE,
+                        PERCENTAGE,
+                    )
+                )
+            if DPCODE_BATTERY_CODE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_BATTERY,
+                        DPCODE_BATTERY_CODE,
+                        PERCENTAGE,
+                    )
+                )
+            if DPCODE_BATTERY_STATE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_BATTERY,
+                        DPCODE_BATTERY_STATE,
+                        "",
+                    )
+                )
 
-        if DPCODE_BATTERY in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_BATTERY,
-                    DPCODE_BATTERY,
-                    PERCENTAGE,
+            if DPCODE_TEMPERATURE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_TEMPERATURE,
+                        DPCODE_TEMPERATURE,
+                        TEMP_CELSIUS,
+                    )
                 )
-            )
-        if DPCODE_BATTERY_PERCENTAGE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_BATTERY,
-                    DPCODE_BATTERY_PERCENTAGE,
-                    PERCENTAGE,
+            if DPCODE_TEMP_CURRENT in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_TEMPERATURE,
+                        DPCODE_TEMP_CURRENT,
+                        TEMP_CELSIUS,
+                    )
                 )
-            )
-        if DPCODE_BATTERY_CODE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_BATTERY,
-                    DPCODE_BATTERY_CODE,
-                    PERCENTAGE,
-                )
-            )
-        if DPCODE_BATTERY_STATE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_BATTERY,
-                    DPCODE_BATTERY_STATE,
-                    "",
-                )
-            )
 
-        if DPCODE_TEMPERATURE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_TEMPERATURE,
-                    DPCODE_TEMPERATURE,
-                    TEMP_CELSIUS,
+            if DPCODE_HUMIDITY in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_HUMIDITY,
+                        DPCODE_HUMIDITY,
+                        PERCENTAGE,
+                    )
                 )
-            )
-        if DPCODE_TEMP_CURRENT in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_TEMPERATURE,
-                    DPCODE_TEMP_CURRENT,
-                    TEMP_CELSIUS,
+            if DPCODE_HUMIDITY_VALUE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_HUMIDITY,
+                        DPCODE_HUMIDITY_VALUE,
+                        PERCENTAGE,
+                    )
                 )
-            )
 
-        if DPCODE_HUMIDITY in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_HUMIDITY,
-                    DPCODE_HUMIDITY,
-                    PERCENTAGE,
+            if DPCODE_PM100_VALUE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device, device_manager, "PM10", DPCODE_PM100_VALUE, "ug/m³"
+                    )
                 )
-            )
-        if DPCODE_HUMIDITY_VALUE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_HUMIDITY,
-                    DPCODE_HUMIDITY_VALUE,
-                    PERCENTAGE,
+            if DPCODE_PM25_VALUE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device, device_manager, "PM2.5", DPCODE_PM25_VALUE, "ug/m³"
+                    )
                 )
-            )
+            if DPCODE_PM10_VALUE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device, device_manager, "PM1.0", DPCODE_PM10_VALUE, "ug/m³"
+                    )
+                )
 
-        if DPCODE_PM100_VALUE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device, device_manager, "PM10", DPCODE_PM100_VALUE, "ug/m³"
+            if DPCODE_CURRENT in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "Current",
+                        DPCODE_CURRENT,
+                        json.loads(device.status_range.get(DPCODE_CURRENT).values).get(
+                            "unit", 0
+                        ),
+                    )
                 )
-            )
-        if DPCODE_PM25_VALUE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device, device_manager, "PM2.5", DPCODE_PM25_VALUE, "ug/m³"
+            if DPCODE_POWER in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_POWER,
+                        DPCODE_POWER,
+                        json.loads(device.status_range.get(DPCODE_POWER).values).get(
+                            "unit", 0
+                        ),
+                    )
                 )
-            )
-        if DPCODE_PM10_VALUE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device, device_manager, "PM1.0", DPCODE_PM10_VALUE, "ug/m³"
+            if DPCODE_TOTAL_FORWARD_ENERGY in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_POWER,
+                        DPCODE_TOTAL_FORWARD_ENERGY,
+                        json.loads(device.status_range.get(DPCODE_TOTAL_FORWARD_ENERGY).values).get(
+                            "unit", 0
+                        ),
+                    )
                 )
-            )
-
-        if DPCODE_CURRENT in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    "Current",
-                    DPCODE_CURRENT,
-                    json.loads(device.status_range.get(DPCODE_CURRENT).values).get(
-                        "unit", 0
-                    ),
+            if DPCODE_VOLTAGE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "Voltage",
+                        DPCODE_VOLTAGE,
+                        json.loads(device.status_range.get(DPCODE_VOLTAGE).values).get(
+                            "unit", 0
+                        ),
+                    )
                 )
-            )
-        if DPCODE_POWER in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_POWER,
-                    DPCODE_POWER,
-                    json.loads(device.status_range.get(DPCODE_POWER).values).get(
-                        "unit", 0
-                    ),
+            if DPCODE_BRIGHT_VALUE in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_ILLUMINANCE,
+                        DPCODE_BRIGHT_VALUE,
+                        json.loads(device.status_range.get(DPCODE_BRIGHT_VALUE).values).get(
+                            "unit", 0
+                        ),
+                    )
                 )
-            )
-        if DPCODE_TOTAL_FORWARD_ENERGY in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_POWER,
-                    DPCODE_TOTAL_FORWARD_ENERGY,
-                    json.loads(device.status_range.get(DPCODE_TOTAL_FORWARD_ENERGY).values).get(
-                        "unit", 0
-                    ),
-                )
-            )
-        if DPCODE_VOLTAGE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    "Voltage",
-                    DPCODE_VOLTAGE,
-                    json.loads(device.status_range.get(DPCODE_VOLTAGE).values).get(
-                        "unit", 0
-                    ),
-                )
-            )
-        if DPCODE_BRIGHT_VALUE in device.status:
-            entities.append(
-                TuyaHaSensor(
-                    device,
-                    device_manager,
-                    DEVICE_CLASS_ILLUMINANCE,
-                    DPCODE_BRIGHT_VALUE,
-                    json.loads(device.status_range.get(DPCODE_BRIGHT_VALUE).values).get(
-                        "unit", 0
-                    ),
-                )
-            )
 
     return entities
 


### PR DESCRIPTION
This PR adds the Air Purifier support. 
Requests: #101 , #104

Purifier support is based on the Fan entity and also uses the switch and sensor entities.
Code was tested using the real HW - Concept CA3000 Air Purifier.

Since I had to touch the switch entity that already uses the "uv" switch. I also updated missing switches for the Pet Water Feeder. This is the entity which uses also the "uv" switch.

![image](https://user-images.githubusercontent.com/2312301/125160213-0ae66e00-e17c-11eb-8d7e-605192044a2b.png)
![image](https://user-images.githubusercontent.com/2312301/125160254-30737780-e17c-11eb-9728-e758f0e6d977.png)
