### PR TITLE
Add Support for DS02 / DS02F Fan Controls

### DIFF
--- a/custom_components/tuya_v2/fan.py
+++ b/custom_components/tuya_v2/fan.py
@@ -51,6 +51,7 @@ DPCODE_AP_FAN_SPEED_ENUM = "fan_speed_enum"
 
 TUYA_SUPPORT_TYPE = {
     "fs",  # Fan
+    "fskg", # Fan (DS02 type)
     "kj",  # Air Purifier
 }
 


### PR DESCRIPTION
This adds support for DS02F (Treatlife brand, and others) type dedicated fan controls. See issues #345 and #138.
