### PR TITLE
Fix for broken brightness setting

### DIFF
--- a/custom_components/tuya_v2/light.py
+++ b/custom_components/tuya_v2/light.py
@@ -222,10 +222,10 @@ class TuyaHaLight(TuyaHaDevice, LightEntity):
             commands += [{"code": self.dp_code_temp, "value": int(color_temp)}]
 
             # brightness
-            ha_brightness = self.brightness
+            new_brightness = kwargs[ATTR_BRIGHTNESS] or self.brightness
             new_range = self._tuya_brightness_range()
             tuya_brightness = self.remap(
-                ha_brightness, 0, 255, new_range[0], new_range[1]
+                new_brightness, 0, 255, new_range[0], new_range[1]
             )
             commands += [{"code": self.dp_code_bright, "value": int(tuya_brightness)}]
 


### PR DESCRIPTION
As report in issue #412 , when color temp and brightness are changed simultaneously, both the current and the new value are sent to the network request and the current value wins out.

This quick fix ensures that this doesn't happen, but a better fix would be to avoid posting the brightness value twice altogether (but the logic of why the brightness is set when the color temp is changed is currently beyond me).