### PR TITLE
Add Smart IR sensors

### DIFF
--- a/custom_components/tuya_v2/sensor.py
+++ b/custom_components/tuya_v2/sensor.py
@@ -59,6 +59,7 @@ TUYA_SUPPORT_TYPE = [
     "kj",  # Air Purifier,
     "xxj",  # Diffuser
     "zndb",  # Smart Electricity Meter
+    "wnykq", # Smart IR
 ]
 
 # Smoke Detector


### PR DESCRIPTION
Some IR devices come with temperature (va_temperature) and humidity(va_humidity) sensors, this PR adds just the sensors for these devices.

I've tested with this device id: eb6319b6c8a8dab3df2hib

And here are the sensors on tuya debug page:

![image](https://user-images.githubusercontent.com/65680394/131937520-1d1be8a0-8196-4564-9bd9-27cf5ffe14a5.png)

And the result:

![image](https://user-images.githubusercontent.com/65680394/131937576-fd7123dd-7ac4-4ad1-ac0d-5a39c9a77997.png)
