### PR TITLE
Add sensors for Multi-functional Alarm (dgnbj)

### DIFF
--- a/custom_components/tuya_v2/sensor.py
+++ b/custom_components/tuya_v2/sensor.py
@@ -59,6 +59,7 @@ TUYA_SUPPORT_TYPE = [
     "kj",  # Air Purifier,
     "xxj",  # Diffuser
     "zndb",  # Smart Electricity Meter
+    "dgnbj", # Multi-functional Alarm
 ]
 
 # Smoke Detector


### PR DESCRIPTION
Closes issue https://github.com/tuya/tuya-home-assistant/issues/435.

Tested with device_id: "bfac779760830c90b0ytkw" 

All the sensors exposed by the tested device are already supported which is not a real alarm and is described as "two in one(Brightness + temperature and humidity)".
This doesn't add support for all possible sensors described in the [documentation](https://developer.tuya.com/en/docs/iot/s?id=K9gf48r2nq2x4).