### PR TITLE
Get correct position for clkg devices & is_closed

### DIFF
--- a/custom_components/tuya_v2/cover.py
+++ b/custom_components/tuya_v2/cover.py
@@ -88,19 +88,37 @@ class TuyaHaCover(TuyaHaDevice, CoverEntity):
 
     @property
     def is_closed(self) -> bool | None:
-        """Return is cover is closed."""
-        return None
+        """Return if cover is closed."""
+        # if device is cl, it has DPCODE_PERCENT_STATE
+        if DPCODE_PERCENT_STATE in self.tuya_device.status:
+            position = self.tuya_device.status.get(DPCODE_PERCENT_STATE, 0)
+            if DPCODE_SITUATION_SET not in self.tuya_device.status:
+                return 100 - position == 0
+            elif self.tuya_device.status.get(DPCODE_SITUATION_SET) == "fully_open":
+                return position == 0
+            else:
+                return 100 - position == 0
+        else:
+            # it's a clkg device
+            position = self.tuya_device.status.get(DPCODE_PERCENT_CONTROL, 0)
+            return position == 0
 
     @property
     def current_cover_position(self) -> int:
         """Return cover current position."""
-        position = self.tuya_device.status.get(DPCODE_PERCENT_STATE, 0)
-        if DPCODE_SITUATION_SET not in self.tuya_device.status:
-            return 1 + int(0.98 * (100 - position))
-        elif self.tuya_device.status.get(DPCODE_SITUATION_SET) == "fully_open":
-            return 1 + 0.98 * position
+        # if device is cl, it has DPCODE_PERCENT_STATE
+        if DPCODE_PERCENT_STATE in self.tuya_device.status:
+            position = self.tuya_device.status.get(DPCODE_PERCENT_STATE, 0)
+            if DPCODE_SITUATION_SET not in self.tuya_device.status:
+                return 1 + int(0.98 * (100 - position))
+            elif self.tuya_device.status.get(DPCODE_SITUATION_SET) == "fully_open":
+                return 1 + 0.98 * position
+            else:
+                return 1 + int(0.98 * (100 - position))
         else:
-            return 1 + int(0.98 * (100 - position))
+            # it's a clkg device
+            position = self.tuya_device.status.get(DPCODE_PERCENT_CONTROL, 0)
+            return position
 
     def open_cover(self, **kwargs: Any) -> None:
         """Open the cover."""


### PR DESCRIPTION
CL devices instructions: https://developer.tuya.com/en/docs/IoT/s?id=K9gf48qy7wkre
CLKG instructions: https://developer.tuya.com/en/docs/iot/s?id=K9gf8rs2668v6

At this moment, only CL devices have the DPCODE_PERCENT_STATE (percent_state) instruction, so when you try to get the position for a clkg device, it's always reporting a wrong value.
This commit splits the logic to grab curtain position depending if is a cl or clkg device.

Also, is_closed() property is affected by this issue, so it's handled aswell.