### PR TITLE
Add support for "manual" mode for Thermostat

### DIFF
--- a/custom_components/tuya_v2/climate.py
+++ b/custom_components/tuya_v2/climate.py
@@ -15,6 +15,7 @@ from homeassistant.components.climate.const import (
     HVAC_MODE_COOL,
     HVAC_MODE_DRY,
     HVAC_MODE_FAN_ONLY,
+    HVAC_MODE_HEAT_COOL,
     HVAC_MODE_HEAT,
     HVAC_MODE_OFF,
     SUPPORT_FAN_MODE,
@@ -70,6 +71,7 @@ SWING_BOTH = "swing_both"
 
 TUYA_HVAC_TO_HA = {
     "hot": HVAC_MODE_HEAT,
+    "manual": HVAC_MODE_HEAT_COOL,
     "cold": HVAC_MODE_COOL,
     "wet": HVAC_MODE_DRY,
     "wind": HVAC_MODE_FAN_ONLY,


### PR DESCRIPTION
Hi !

I had errors with the following Thermostat so I implemented support for the Tuya 'manual' mode  :
https://www.aliexpress.com/item/1005001357954053.html?spm=a2g0s.9042311.0.0.21044c4dvnhO7e 

I'd be happy to get any comments / feedback on this PR

Cheers,
Laurent

---


**The integration broke when the Thermostat was in "manual" mode :** 
`Logger: homeassistant
Source: custom_components/tuya_v2/climate.py:361
Integration: Tuya v2 (documentation)
First occurred: October 5, 2021, 11:25:55 PM (11 occurrences)
Last logged: 7:47:36 PM

```
Error doing job: Task exception was never retrieved
Traceback (most recent call last):
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 443, in async_update_ha_state
    self._async_write_ha_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 489, in _async_write_ha_state
    state = self._stringify_state()
  File "/usr/src/homeassistant/homeassistant/helpers/entity.py", line 462, in _stringify_state
    if (state := self.state) is None:
  File "/usr/src/homeassistant/homeassistant/components/climate/__init__.py", line 210, in state
    return self.hvac_mode
  File "/config/custom_components/tuya_v2/climate.py", line 361, in hvac_mode
    return TUYA_HVAC_TO_HA[self.tuya_device.status.get(DPCODE_MODE)]
KeyError: 'manual'
```

**Reference documentation**
Tuya mode for manual : https://developer.tuya.com/en/docs/iot/s?id=K9gf48r3k5ctd

