### PR TITLE
Additional sensors + "keep warm" switch for Kettle

### DIFF
--- a/custom_components/tuya_v2/sensor.py
+++ b/custom_components/tuya_v2/sensor.py
@@ -26,6 +26,7 @@ from homeassistant.const import (
     MASS_MILLIGRAMS,
     PERCENTAGE,
     TEMP_CELSIUS,
+    TEMP_FAHRENHEIT,
     TIME_DAYS,
     TIME_MINUTES,
 )
@@ -67,6 +68,7 @@ TUYA_SUPPORT_TYPE = [
     "xxj",  # Diffuser
     "zndb",  # Smart Electricity Meter
     "wnykq", # Smart IR
+    "bh",    # Smart Kettle
 ]
 
 # Smoke Detector
@@ -83,6 +85,7 @@ DPCODE_PM100_VALUE = "pm100_value"
 DPCODE_PM25_VALUE = "pm25_value"
 DPCODE_PM10_VALUE = "pm10_value"
 
+DPCODE_TEMP_UNIT_CONVERT = "temp_unit_convert"
 DPCODE_TEMP_CURRENT = "temp_current"
 DPCODE_HUMIDITY_VALUE = "humidity_value"
 
@@ -93,6 +96,8 @@ DPCODE_TOTAL_FORWARD_ENERGY = "total_forward_energy"
 DPCODE_ADD_ELE = "add_ele"
 
 DPCODE_BRIGHT_VALUE = "bright_value"
+
+DPCODE_STATUS = "status"
 
 # Residential Lock
 # https://developer.tuya.com/en/docs/iot/f?id=K9i5ql58frxa2
@@ -278,6 +283,29 @@ def _setup_entities(
                         DPCODE_AP_COUNTDOWN,
                         TIME_MINUTES,
                         None,
+                    )
+                )
+        elif device.category == "bh":
+            if DPCODE_TEMP_CURRENT in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        DEVICE_CLASS_TEMPERATURE,
+                        DPCODE_TEMP_CURRENT,
+                        TEMP_FAHRENHEIT if (device.status.get(DPCODE_TEMP_UNIT_CONVERT) == "f") else TEMP_CELSIUS,
+                        STATE_CLASS_MEASUREMENT,
+                    )
+                )
+            if DPCODE_STATUS in device.status:
+                entities.append(
+                    TuyaHaSensor(
+                        device,
+                        device_manager,
+                        "Status",
+                        DPCODE_STATUS,
+                        "",
+                        "",
                     )
                 )
         else:
@@ -579,4 +607,4 @@ class TuyaHaSensor(TuyaHaEntity, SensorEntity):
             if __value_range.get("scale") == 0:
                 return int(__state)
             return f"%.{__value_range.get('scale')}f" % __state
-        return ""
+        return __value

--- a/custom_components/tuya_v2/switch.py
+++ b/custom_components/tuya_v2/switch.py
@@ -64,6 +64,8 @@ DPCODE_WRESET = "water_reset"  # Pet Water Feeder - Resetting of water usage day
 DPCODE_START = "start"
 # Coffee Maker
 # https://developer.tuya.com/en/docs/iot/f?id=K9gf4701ox167
+# Smart Kettle
+# https://developer.tuya.com/en/docs/iot/categorybh?id=Kaiuz2kly679h
 DPCODE_PAUSE = "pause"
 DPCODE_WARM = "warm"
 DPCODE_CLEANING = "cleaning"
@@ -139,7 +141,7 @@ def _setup_entities(hass, entry: ConfigEntry, device_ids: list[str]) -> list[Ent
                     entities.append(TuyaHaSwitch(device, device_manager, function))
                     tuya_ha_switch = TuyaHaSwitch(device, device_manager, function)
 
-            elif device.category == "kfj":
+            elif device.category == "kfj" or device.category == "bh":
                 if function in [
                     DPCODE_SWITCH,
                     DPCODE_START,


### PR DESCRIPTION
This PR add a Temperature and Status sensor as well as a Keep Warm switch for Smart Kettle.
Tested with Korex Smart Electric Water Kettle (model AX-WF306)

Device information from logs:
```json
 "result": {
    "category": "bh",
    "functions": [
      {
        "code": "start",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "temp_setting_quick_c",
        "type": "Enum",
        "values": "{\"range\":[\"50\",\"65\",\"85\",\"90\"]}"
      },
      {
        "code": "temp_boiling_quick_c",
        "type": "Enum",
        "values": "{\"range\":[\"50\",\"65\",\"85\",\"90\",\"100\"]}"
      },
      {
        "code": "warm",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "temp_unit_convert",
        "type": "Enum",
        "values": "{\"range\":[\"c\",\"f\"]}"
      }
    ],
    "status": [
      {
        "code": "start",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "temp_current",
        "type": "Integer",
        "values": "{\"unit\":\"℃\",\"min\":0,\"max\":212,\"scale\":0,\"step\":1}"
      },
      {
        "code": "temp_setting_quick_c",
        "type": "Enum",
        "values": "{\"range\":[\"50\",\"65\",\"85\",\"90\"]}"
      },
      {
        "code": "temp_boiling_quick_c",
        "type": "Enum",
        "values": "{\"range\":[\"50\",\"65\",\"85\",\"90\",\"100\"]}"
      },
      {
        "code": "warm",
        "type": "Boolean",
        "values": "{}"
      },
      {
        "code": "status",
        "type": "Enum",
        "values": "{\"range\":[\"standby\",\"heating\",\"cooling\",\"warm\",\"heating_temp\"]}"
      },
      {
        "code": "temp_unit_convert",
        "type": "Enum",
        "values": "{\"range\":[\"c\",\"f\"]}"
      }
    ]
  }
```