### PR TITLE
Add support for dimmer light category in light.py

### DIFF
--- a/custom_components/tuya_v2/light.py
+++ b/custom_components/tuya_v2/light.py
@@ -67,6 +67,7 @@ TUYA_SUPPORT_TYPE = {
     "xdd",  # Ceiling Light
     "xxj",  # Diffuser's light
     "fs",  # Fan
+    "tgq", # Dimmers
 }
 
 DEFAULT_HSV = {


### PR DESCRIPTION
Resolves dimmer syncing issue that some people are having like https://github.com/tuya/tuya-home-assistant/issues/594. Support for other device categories, like at least those documented at https://www.reddit.com/r/homeassistant/comments/q2rhy3/how_is_the_official_tuya_v2_integration_worse/ (`fs`, `fskg`, `ckmkzq`) is needed as well.